### PR TITLE
Fix: Improve layout of action buttons on mobile

### DIFF
--- a/src/components/RosterDisplay.jsx
+++ b/src/components/RosterDisplay.jsx
@@ -14,7 +14,8 @@ import {
   Typography,
   Snackbar,
   IconButton,
-  Tooltip
+  Tooltip,
+  Stack
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import * as XLSX from 'xlsx';
@@ -539,7 +540,12 @@ function RosterDisplay({ roster, volunteers, ministries, startYear, startMonth, 
     <div className="roster-display card">
       <div className="roster-header">
         <h3>{rosterPeriodTitle}</h3>
-        <div style={{ display: 'flex', gap: '10px', marginLeft: 'auto' }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={'10px'}
+          sx={{ marginLeft: 'auto' }}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+        >
           <Tooltip title="Copy shareable link to clipboard">
             <Button 
               variant="outlined" 
@@ -559,7 +565,7 @@ function RosterDisplay({ roster, volunteers, ministries, startYear, startMonth, 
           >
             Export to Excel
           </Button>
-        </div>
+        </Stack>
       </div>
       <p><small>Drag and drop a person's name to swap positions between the same roles on different dates, or drag an entire box to swap all people assigned to that role between dates. Click on a person to edit directly.</small></p>
       {sortedYearMonthKeys.map(ymKey => {


### PR DESCRIPTION
The "Copy share link" and "Export to Excel" buttons in the RosterDisplay component were previously in a fixed horizontal row, which could cause layout issues on smaller mobile screens.

This change replaces the simple div wrapper with Material UI's `Stack` component. The `Stack` is configured to:
- Display buttons in a column (`direction='column'`) on extra-small (xs) screens.
- Display buttons in a row (`direction='row'`) on small (sm) screens and larger.
- Maintain a 10px gap between buttons.
- Stretch buttons to full width of the Stack on xs screens for better mobile usability.

This ensures the buttons are always visible and accessible, adapting their layout to the available screen width.